### PR TITLE
CPMR0041 and CPMR0050 for glab.nuspec and glab.portable.nuspec; Fixes #4

### DIFF
--- a/packages/glab.portable/glab.portable.nuspec
+++ b/packages/glab.portable/glab.portable.nuspec
@@ -6,14 +6,14 @@
     <version>1.24.1</version>
     <packageSourceUrl>https://github.com/corbob/ChocoPackages/tree/master/packages/glab.portable</packageSourceUrl>
     <owners>corbob</owners>
-    <title>glab (Portable)</title>
+    <title>GLab (Portable)</title>
     <authors>GitLab</authors>
     <projectUrl>https://gitlab.com/gitlab-org/cli</projectUrl>
     <iconUrl>https://cdn.jsdelivr.net/gh/corbob/ChocoPackages@master/icons/glab.png</iconUrl>
     <copyright>2022 GitLab</copyright>
     <licenseUrl>https://gitlab.com/gitlab-org/cli/-/blob/trunk/LICENSE</licenseUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
-    <projectSourceUrl>https://gitlab.com/gitlab-org/cli</projectSourceUrl>
+    <projectSourceUrl>https://gitlab.com/gitlab-org/cli/-/tree/v1.24.1</projectSourceUrl>
     <tags>glab gitlab</tags>
     <summary>A GitLab CLI tool bringing GitLab to your command line</summary>
     <description>GLab is an open source GitLab CLI tool bringing GitLab to your terminal next to where you are already working with `git` and your code without switching between windows and browser tabs. Work with issues, merge requests, **watch running pipelines directly from your CLI** among other features.

--- a/packages/glab/glab.nuspec
+++ b/packages/glab/glab.nuspec
@@ -6,14 +6,14 @@
     <version>1.24.1</version>
     <packageSourceUrl>https://github.com/corbob/ChocoPackages/tree/master/packages/glab</packageSourceUrl>
     <owners>corbob</owners>
-    <title>glab</title>
+    <title>GLab</title>
     <authors>GitLab</authors>
     <projectUrl>https://gitlab.com/gitlab-org/cli</projectUrl>
     <iconUrl>https://cdn.jsdelivr.net/gh/corbob/ChocoPackages@master/icons/glab.png</iconUrl>
     <copyright>2022 GitLab</copyright>
     <licenseUrl>https://gitlab.com/gitlab-org/cli/-/blob/trunk/LICENSE</licenseUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
-    <projectSourceUrl>https://gitlab.com/gitlab-org/cli</projectSourceUrl>
+    <projectSourceUrl>https://gitlab.com/gitlab-org/cli/-/tree/v1.24.1</projectSourceUrl>
     <tags>glab gitlab</tags>
     <summary>A GitLab CLI tool bringing GitLab to your command line</summary>
     <description>GLab is an open source GitLab CLI tool bringing GitLab to your terminal next to where you are already working with `git` and your code without switching between windows and browser tabs. Work with issues, merge requests, **watch running pipelines directly from your CLI** among other features.


### PR DESCRIPTION
Fixes #4

Now adheres to both guidelines [CPMR0041](https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0041) and [CPMR0050](https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0050) for files `glab.nuspec` and `glab.portable.nuspec`

No need to push to Chocolatey soon as "Guidelines are strong suggestions", not breaking despite "Requirements will hold up a package version from approval." (both in the original [Wayback](https://web.archive.org/web/20221208111646/https://community.chocolatey.org/packages/glab/1.24.1)/[Archive](https://archive.vn/2022.12.08-111648/https://community.chocolatey.org/packages/glab/1.24.1) [1.24.1 submission](https://community.chocolatey.org/packages/glab/1.24.1)).

As [according to Rob Reynolds this is the order of steps](https://twitter.com/ferventcoder/status/1600895208446521346), push is not yet needed, so these changes can be pushed later on when a new version release of GLab has been released.